### PR TITLE
Add IronClaw to Networking/Runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ A collection of container related security resources
 ### [gVisor](https://github.com/google/gvisor)
 * User-space kernel designed to provide better isolation/sandboxing of containers
 
+### [IronClaw](https://github.com/IronSecCo/ironclaw)
+* gVisor-isolated runtime that sandboxes AI agent tool-calls, with an approval gateway, encrypted task queues, and signed, attested builds
+
+
 ### [Cilium](https://github.com/cilium/cilium)
 * Network policy enforcement based on eBPF
 * [Cilium - Container Security and Networking Using BPF and XDP - Thomas Graf, Covalent](https://www.youtube.com/watch?v=CcGtDMm1SJA) - Presentation of Cilium by its creator


### PR DESCRIPTION
Adds **IronClaw** (https://github.com/IronSecCo/ironclaw) under **Networking/Runtime**, next to the gVisor entry.

IronClaw is an open-source (AGPL-3.0) runtime that uses gVisor to sandbox AI agent tool-calls, adding an approval gateway, encrypted task queues, and signed, attested builds. It applies the container-isolation techniques in this list (gVisor application-kernel isolation) to the emerging AI-agent execution use case.

Single entry, matching the existing H3 + bullet format.